### PR TITLE
Fix native linux halley-cmd tool build 

### DIFF
--- a/cmake/HalleyProject.cmake
+++ b/cmake/HalleyProject.cmake
@@ -32,8 +32,8 @@ if (DEV_BUILD EQUAL 1)
 endif()
 
 
-# C++14 support
-set(CMAKE_CXX_STANDARD 14)
+# C++17 support
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -stdlib=libc++") # Apparently Clang on Mac needs this...

--- a/src/plugins/sdl/CMakeLists.txt
+++ b/src/plugins/sdl/CMakeLists.txt
@@ -31,4 +31,4 @@ assign_source_group(${SOURCES})
 assign_source_group(${HEADERS})
 
 add_library (halley-sdl ${SOURCES} ${HEADERS})
-target_link_libraries(halley-sdl halley-core)
+target_link_libraries(halley-sdl halley-core ${SDL2_LIBRARIES})

--- a/src/tools/tools/CMakeLists.txt
+++ b/src/tools/tools/CMakeLists.txt
@@ -149,4 +149,5 @@ target_link_libraries (halley-tools
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${YAMLCPP_LIBRARY}
+    ${CMAKE_DL_LIBS}
     )

--- a/src/tools/tools/src/assets/check_assets_task.cpp
+++ b/src/tools/tools/src/assets/check_assets_task.cpp
@@ -244,11 +244,14 @@ std::vector<ImportAssetsDatabaseEntry> CheckAssetsTask::filterNeedsImporting(Imp
 Maybe<Path> CheckAssetsTask::findDirectoryMeta(const std::vector<Path>& metas, const Path& path) const
 {
 	auto parent = path.parentPath();
+	Maybe<Path> longestPath;
 	for (auto& m: metas) {
-		auto n = m.getNumberPaths() - 1;
-		if (m.getFront(n) == parent.getFront(n)) {
-			return m;
+		if (!longestPath || longestPath->getNumberPaths() < m.getNumberPaths()) {
+			auto n = m.getNumberPaths() - 1;
+			if (m.getFront(n) == parent.getFront(n)) {
+				longestPath = m;
+			}
 		}
 	}
-	return {};
+	return longestPath;
 }

--- a/src/tools/tools/src/assets/check_assets_task.cpp
+++ b/src/tools/tools/src/assets/check_assets_task.cpp
@@ -69,20 +69,19 @@ static void loadMetaData(Metadata& meta, const Path& path, bool isDirectoryMeta,
 	if (isDirectoryMeta) {
 		for (const auto& rootList: root) {
 			bool matches = true;
-			for (YAML::const_iterator i0 = rootList.begin(); i0 != rootList.end(); ++i0) {
-				auto name = i0->first.as<std::string>();
-				if (name == "match") {
-					matches = false;
-					for (auto& pattern: i0->second) {
-						if (assetId.contains(pattern.as<std::string>())) {
-							matches = true;
-							break;
-						}
+			if (rootList["match"]) {
+				matches = false;
+				for (auto& pattern: rootList["match"]) {
+					auto p = pattern.as<std::string>();
+					if (assetId.contains(p)) {
+						matches = true;
+						break;
 					}
-				} else if (name == "data" && matches) {
-					loadMetaTable(meta, i0->second);
-					return;
 				}
+			}
+			if (matches && rootList["data"]) {
+				loadMetaTable(meta, rootList["data"]);
+				return;
 			}
 		}
 	} else {

--- a/src/tools/tools/src/project/project_loader.cpp
+++ b/src/tools/tools/src/project/project_loader.cpp
@@ -95,7 +95,7 @@ HalleyPluginPtr ProjectLoader::loadPlugin(const Path& path)
 #else
 
 	// Warning: untested on Mac/Linux :)
-	auto module = dlopen(path.c_str(), RTLD_LAZY);
+	auto module = dlopen(path.getString().c_str(), RTLD_LAZY);
 	if (!module) {
 		return {};
 	}


### PR DESCRIPTION
The commits included fix a handful of compiler and linker errors that prevent building the halley-cmd tool on Linux (Ubuntu 16.04, CMake 3.12, GCC 7.3), and a couple of minor tool bugs that prevent building projects.