### PR TITLE
OSLinux: Use XDG_DATA_HOME for user data dir

### DIFF
--- a/src/engine/utils/src/os/os_linux.cpp
+++ b/src/engine/utils/src/os/os_linux.cpp
@@ -97,14 +97,17 @@ Path OSLinux::parseProgramPath(const String& path)
 String OSLinux::getUserDataDir()
 {
 	String result;
-	struct passwd* pwd = getpwuid(getuid());
-	if (pwd) {
-		result = pwd->pw_dir;
-	} else {
-		result = getenv("HOME");
+
+	if (!(result = getenv("XDG_DATA_HOME")).isEmpty()) {
+		return result;
+	} else if ((result = getenv("HOME")).isEmpty()) {
+		struct passwd* pwd = getpwuid(getuid());
+		if ((result = pwd->pw_dir).isEmpty()) {
+			throw Exception("Unable to find path to user data directory.", HalleyExceptions::OS);
+		}
 	}
 
-	return result + "/Library/";
+	return result + "/.local/share";
 }
 
 #endif


### PR DESCRIPTION
So far it was even set to `$HOME/Library` which I think is not a very good default and looks a lot like it was copied over from the OS X implementation.

The [XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) is out there since about 10 years or even more, so let's look up the `XDG_DATA_HOME` environment variable and if it's not set, fall back to `~/.local/share` as in the specification.

I did this change, because I'm very much looking forward to [packaging](https://github.com/openlab-aux/vuizvui/tree/master/pkgs/games) WarGroove and don't want to fix it up via binary patching or `LD_PRELOAD` once the game is released :smiley:

One thing to note however is that I didn't test this, as the examples are no longer in par with the current API.