### PR TITLE
can set a sprite clip as absolute instead of relative

### DIFF
--- a/src/engine/core/include/halley/core/graphics/sprite/sprite.h
+++ b/src/engine/core/include/halley/core/graphics/sprite/sprite.h
@@ -96,6 +96,7 @@ namespace Halley
 		bool isVisible() const;
 
 		Sprite& setClip(Rect4f clip);
+		Sprite& setAbsoluteClip(Rect4f clip);
 		Sprite& setClip();
 		Maybe<Rect4f> getClip() const;
 
@@ -115,6 +116,7 @@ namespace Halley
 		Vector4s slices;
 		Vector4s outerBorder;
 		Maybe<Rect4f> clip;
+		bool absoluteClip = false;
 		bool visible = true;
 		bool flip = false;
 		bool sliced = false;

--- a/src/engine/core/src/graphics/sprite/sprite.cpp
+++ b/src/engine/core/src/graphics/sprite/sprite.cpp
@@ -32,7 +32,7 @@ void Sprite::drawNormal(Painter& painter) const
 	Expects(material->getDefinition().getVertexStride() == sizeof(SpriteVertexAttrib));
 	
 	if (clip) {
-		painter.setRelativeClip(clip.get() + vertexAttrib.pos);
+		painter.setRelativeClip(clip.get() + (absoluteClip ? Vector2f() : vertexAttrib.pos));
 	}
 	painter.drawSprites(material, 1, &vertexAttrib);
 	if (clip) {
@@ -375,12 +375,21 @@ bool Sprite::isVisible() const
 Sprite& Sprite::setClip(Rect4f c)
 {
 	clip = c;
+	absoluteClip = false;
+	return *this;
+}
+
+Sprite& Sprite::setAbsoluteClip(Rect4f c)
+{
+	clip = c;
+	absoluteClip = true;
 	return *this;
 }
 
 Sprite& Sprite::setClip()
 {
 	clip.reset();
+	absoluteClip = false;
 	return *this;
 }
 


### PR DESCRIPTION
Will be used for clipping particles in the cutscen editor.