### PR TITLE
Hackily fix compile errors in the tests.

### DIFF
--- a/src/tests/audio/assets_src/audio_event/a1.yaml
+++ b/src/tests/audio/assets_src/audio_event/a1.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ a1.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/a1s.yaml
+++ b/src/tests/audio/assets_src/audio_event/a1s.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ a1s.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/b1.yaml
+++ b/src/tests/audio/assets_src/audio_event/b1.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ b1.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/c1.yaml
+++ b/src/tests/audio/assets_src/audio_event/c1.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ c1.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/c1s.yaml
+++ b/src/tests/audio/assets_src/audio_event/c1s.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ c1s.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/d1.yaml
+++ b/src/tests/audio/assets_src/audio_event/d1.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ d1.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/d1s.yaml
+++ b/src/tests/audio/assets_src/audio_event/d1s.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ d1s.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/e1.yaml
+++ b/src/tests/audio/assets_src/audio_event/e1.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ e1.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/f1.yaml
+++ b/src/tests/audio/assets_src/audio_event/f1.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ f1.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/f1s.yaml
+++ b/src/tests/audio/assets_src/audio_event/f1s.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ f1s.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/g1.yaml
+++ b/src/tests/audio/assets_src/audio_event/g1.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ g1.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/g1s.yaml
+++ b/src/tests/audio/assets_src/audio_event/g1s.yaml
@@ -1,0 +1,4 @@
+actions:
+  - type: play
+    clips: [ g1s.ogg ]
+    group: key

--- a/src/tests/audio/assets_src/audio_event/loveshadow.yaml
+++ b/src/tests/audio/assets_src/audio_event/loveshadow.yaml
@@ -1,0 +1,5 @@
+actions:
+  - type: play
+    clips: [ Loveshadow_-_Marcos_Theme.ogg ]
+    group: music
+    loop: true

--- a/src/tests/audio/src/main.cpp
+++ b/src/tests/audio/src/main.cpp
@@ -4,7 +4,7 @@
 using namespace Halley;
 
 void initOpenGLPlugin(IPluginRegistry &registry);
-void initSDLSystemPlugin(IPluginRegistry &registry);
+void initSDLSystemPlugin(IPluginRegistry &registry, Maybe<String> cryptKey);
 void initSDLAudioPlugin(IPluginRegistry &registry);
 void initSDLInputPlugin(IPluginRegistry &registry);
 
@@ -20,16 +20,16 @@ class AudioTestGame final : public Game
 public:
 	int initPlugins(IPluginRegistry &registry) override
 	{
-		initSDLSystemPlugin(registry);
+		initSDLSystemPlugin(registry, {});
 		initSDLAudioPlugin(registry);
 		initSDLInputPlugin(registry);
 		initOpenGLPlugin(registry);
 		return HalleyAPIFlags::Video | HalleyAPIFlags::Audio | HalleyAPIFlags::Input;
 	}
 
-	void initResourceLocator(Path dataPath, ResourceLocator& locator) override
+	void initResourceLocator(const Path& gamePath, const Path& assetsPath, const Path& unpackedAssetsPath, ResourceLocator& locator) override
 	{
-		locator.addFileSystem(dataPath);
+		locator.addFileSystem(unpackedAssetsPath);
 	}
 
 	std::unique_ptr<Stage> makeStage(StageID id) override
@@ -52,7 +52,7 @@ public:
 		return "halley/audio-test";
 	}
 
-	bool isDevBuild() const override
+	bool isDevMode() const override
 	{
 		return true;
 	}
@@ -60,7 +60,7 @@ public:
 	std::unique_ptr<Stage> startGame(const HalleyAPI* api) override
 	{
 		api->audio->startPlayback();
-		api->video->setWindow(WindowDefinition(WindowType::Window, Vector2i(1280, 720), getName()), true);
+		api->video->setWindow(WindowDefinition(WindowType::Window, Vector2i(1280, 720), getName()));
 		return std::make_unique<TestStage>();
 	}
 };

--- a/src/tests/audio/src/test_stage.cpp
+++ b/src/tests/audio/src/test_stage.cpp
@@ -5,7 +5,7 @@ using namespace Halley;
 
 void TestStage::init()
 {
-	getAudioAPI().playMusic(getResource<AudioClip>("Loveshadow_-_Marcos_Theme.ogg"));
+	getAudioAPI().play(getResource<AudioClip>("Loveshadow_-_Marcos_Theme.ogg"), AudioPosition());
 }
 
 void TestStage::onVariableUpdate(Time time)
@@ -32,7 +32,7 @@ void TestStage::onVariableUpdate(Time time)
 	auto noteSamples = std::array<String, 12>{{ "c1", "c1s", "d1", "d1s", "e1", "f1", "f1s", "g1", "g1s", "a1", "a1s", "b1" }};
 	for (int i = 0; i < 12; ++i) {
 		if (key->isButtonPressed(noteKeys[i])) {
-			getAudioAPI().playUI(getResources().get<AudioClip>(noteSamples[i] + ".ogg"), 1.0f, pan);
+			getAudioAPI().play(getResources().get<AudioClip>(noteSamples[i] + ".ogg"), AudioPosition::makeUI(pan));
 		}
 	}
 }

--- a/src/tests/audio/src/test_stage.cpp
+++ b/src/tests/audio/src/test_stage.cpp
@@ -5,7 +5,7 @@ using namespace Halley;
 
 void TestStage::init()
 {
-	getAudioAPI().play(getResource<AudioClip>("Loveshadow_-_Marcos_Theme.ogg"), AudioPosition());
+	getAudioAPI().playMusic("loveshadow");
 }
 
 void TestStage::onVariableUpdate(Time time)
@@ -32,7 +32,7 @@ void TestStage::onVariableUpdate(Time time)
 	auto noteSamples = std::array<String, 12>{{ "c1", "c1s", "d1", "d1s", "e1", "f1", "f1s", "g1", "g1s", "a1", "a1s", "b1" }};
 	for (int i = 0; i < 12; ++i) {
 		if (key->isButtonPressed(noteKeys[i])) {
-			getAudioAPI().play(getResources().get<AudioClip>(noteSamples[i] + ".ogg"), AudioPosition::makeUI(pan));
+			getAudioAPI().postEvent(noteSamples[i], AudioPosition::makeUI(pan));
 		}
 	}
 }

--- a/src/tests/entity/src/main.cpp
+++ b/src/tests/entity/src/main.cpp
@@ -4,7 +4,7 @@
 using namespace Halley;
 
 void initOpenGLPlugin(IPluginRegistry &registry);
-void initSDLSystemPlugin(IPluginRegistry &registry);
+void initSDLSystemPlugin(IPluginRegistry &registry, Maybe<String> cryptKey);
 void initSDLAudioPlugin(IPluginRegistry &registry);
 void initSDLInputPlugin(IPluginRegistry &registry);
 
@@ -33,16 +33,16 @@ class EntityTestGame final : public Game
 public:
 	int initPlugins(IPluginRegistry &registry) override
 	{
-		initSDLSystemPlugin(registry);
+		initSDLSystemPlugin(registry, {});
 		initSDLAudioPlugin(registry);
 		initSDLInputPlugin(registry);
 		initOpenGLPlugin(registry);
 		return HalleyAPIFlags::Video | HalleyAPIFlags::Audio | HalleyAPIFlags::Input;
 	}
 
-	void initResourceLocator(Path dataPath, ResourceLocator& locator) override
+	void initResourceLocator(const Path& gamePath, const Path& assetsPath, const Path& unpackedAssetsPath, ResourceLocator& locator) override
 	{
-		locator.addFileSystem(dataPath);
+		locator.addFileSystem(unpackedAssetsPath);
 	}
 
 	std::unique_ptr<Stage> makeStage(StageID id) override
@@ -69,14 +69,14 @@ public:
 		return "halley/entity-test";
 	}
 
-	bool isDevBuild() const override
+	bool isDevMode() const override
 	{
 		return true;
 	}
 
 	std::unique_ptr<Stage> startGame(const HalleyAPI* api) override
 	{
-		api->video->setWindow(WindowDefinition(WindowType::Window, Vector2i(1280, 720), getName()), true);
+		api->video->setWindow(WindowDefinition(WindowType::Window, Vector2i(1280, 720), getName()));
 		return std::make_unique<TestStage>();
 	}
 };

--- a/src/tests/entity/src/systems/render_system.cpp
+++ b/src/tests/entity/src/systems/render_system.cpp
@@ -12,13 +12,13 @@ public:
 		for (auto& e : mainFamily) {
 			auto& sprite = e.sprite.sprite;
 			sprite.setPos(e.position.position);
-			spritePainter.add(sprite, 0, e.sprite.layer, sprite.getPosition().y);
+			spritePainter.add(sprite, 1, e.sprite.layer, sprite.getPosition().y);
 		}
 
 		rc.bind([&] (Painter& painter)
 		{
 			painter.clear(Colour());
-			spritePainter.draw(0, painter);
+			spritePainter.draw(1, painter);
 			painter.flush();
 		});
 	}

--- a/src/tests/entity/src/test_stage.cpp
+++ b/src/tests/entity/src/test_stage.cpp
@@ -6,7 +6,10 @@ using namespace Halley;
 void TestStage::init()
 {
 	world = createWorld("sample_test_world", createSystem);
-	statsView = std::make_unique<WorldStatsView>(*getAPI().core, *world);
+	statsView = std::make_unique<WorldStatsView>(*getAPI().core);
+	auto stolen = world.release();
+	world.reset(stolen);
+	statsView->setWorld(stolen);
 }
 
 void TestStage::onFixedUpdate(Time time)

--- a/src/tests/entity/src/test_stage.cpp
+++ b/src/tests/entity/src/test_stage.cpp
@@ -7,9 +7,7 @@ void TestStage::init()
 {
 	world = createWorld("sample_test_world", createSystem);
 	statsView = std::make_unique<WorldStatsView>(*getAPI().core);
-	auto stolen = world.release();
-	world.reset(stolen);
-	statsView->setWorld(stolen);
+	statsView->setWorld(world.get());
 }
 
 void TestStage::onFixedUpdate(Time time)

--- a/src/tests/network/src/main.cpp
+++ b/src/tests/network/src/main.cpp
@@ -14,9 +14,9 @@ public:
 		return HalleyAPIFlags::Video | HalleyAPIFlags::Audio | HalleyAPIFlags::Input;
 	}
 
-	void initResourceLocator(Path dataPath, ResourceLocator& locator) override
+	void initResourceLocator(const Path& gamePath, const Path& assetsPath, const Path& unpackedAssetsPath, ResourceLocator& locator) override
 	{
-		locator.addFileSystem(dataPath);
+		locator.addFileSystem(unpackedAssetsPath);
 	}
 
 	String getName() const override
@@ -29,14 +29,14 @@ public:
 		return "halley/network-test";
 	}
 
-	bool isDevBuild() const override
+	bool isDevMode() const override
 	{
 		return true;
 	}
 
 	std::unique_ptr<Stage> startGame(const HalleyAPI* api) override
 	{
-		api->video->setWindow(WindowDefinition(WindowType::Window, Vector2i(1280, 720), getName()), false);
+		api->video->setWindow(WindowDefinition(WindowType::Window, Vector2i(1280, 720), getName()));
 		return std::make_unique<TestStage>();
 	}
 };


### PR DESCRIPTION
I'm not quite sure how to run the tests, but some things I probably did wrong:

 * In the AudioTest, couldn't figure out the right way to pass an
   `AudioClip` to `AudioAPI::play`. The original test set up a background
   track; pretty sure `AudioAPI::play` doesn't quite do that.
 * In the EntityTest, during `TestState::init`, a `World` reference is
   stolen from a `unique_ptr`. There's an API mismatch wherein `createWorld` returns a
   `unique_ptr<World>`, but `StatsView::setWorld` wants an unmanaged pointer
   (and doesn't take ownership of it). Stealing the pointer (via
   `unique_ptr::release`/`unique_ptr::reset`) is terrible, but I'm not sure
   how the ownership semantics should work.
 * In the EntityTest, the mask passed to `SpritePainter::add` was `0`; this
   causes the sprite to never be drawn (via `SpritePainter::draw`; the
   `getMask() & mask` check fails). I'm not entirely sure what the mask does,
   but setting it to 1 makes something (albeit incorrect) renders. I think
   the assets might be out-of-date? But the animation frames don't look
   like they have the right texture coordinates.

I believe this fixes #32