### PR TITLE
Add FreeBSD support.

### DIFF
--- a/src/engine/core/include/halley/core/game/game_platform.h
+++ b/src/engine/core/include/halley/core/game/game_platform.h
@@ -16,12 +16,13 @@ namespace Halley {
 		UWP,
 		Android,
 		iOS,
-        Emscripten
+        Emscripten,
+		FreeBSD
 	};
 
 	template <>
 	struct EnumNames<GamePlatform> {
-		constexpr std::array<const char*, 11> operator()() const {
+		constexpr std::array<const char*, 12> operator()() const {
 			return {{
 				"unknown",
 				"windows",
@@ -33,7 +34,8 @@ namespace Halley {
 				"uwp",
 				"android",
 				"ios",
-                "emscripten"
+                "emscripten",
+				"freebsd"
 			}};
 		}
 	};
@@ -62,6 +64,8 @@ namespace Halley {
         #endif
     #elif defined(__linux)
         return GamePlatform::Linux;
+    #elif defined(__FreeBSD__)
+        return GamePlatform::FreeBSD;
     #else
         return GamePlatform::Unknown;
     #endif

--- a/src/engine/utils/CMakeLists.txt
+++ b/src/engine/utils/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SOURCES
         "src/os/os.cpp"
         "src/os/os_ios.cpp"
         "src/os/os_linux.cpp"
+        "src/os/os_freebsd.cpp"
         "src/os/os_mac.cpp"
         "src/os/os_unix.cpp"
         "src/os/os_win32.cpp"

--- a/src/engine/utils/src/os/os.cpp
+++ b/src/engine/utils/src/os/os.cpp
@@ -25,6 +25,7 @@
 #include "os_android.h"
 #include "os_ios.h"
 #include "os_linux.h"
+#include "os_freebsd.h"
 #include "halley/support/exception.h"
 #include <fstream>
 
@@ -52,6 +53,8 @@ OS* OS::createOS()
 	return new OSiOS();
 #elif defined(linux)
 	return new OSLinux();
+#elif defined(__FreeBSD__)
+	return new OSFreeBSD();
 #else
 	return new OS();
 #endif

--- a/src/engine/utils/src/os/os_freebsd.cpp
+++ b/src/engine/utils/src/os/os_freebsd.cpp
@@ -1,0 +1,138 @@
+/*****************************************************************\
+           __
+          / /
+		 / /                     __  __
+		/ /______    _______    / / / / ________   __       __
+	   / ______  \  /_____  \  / / / / / _____  | / /      / /
+	  / /      | / _______| / / / / / / /____/ / / /      / /
+	 / /      / / / _____  / / / / / / _______/ / /      / /
+	/ /      / / / /____/ / / / / / / |______  / |______/ /
+   /_/      /_/ |________/ / / / /  \_______/  \_______  /
+                          /_/ /_/                     / /
+			                                         / /
+		       High Level Game Framework            /_/
+
+  ---------------------------------------------------------------
+
+  Copyright (c) 2007-2017 - Rodrigo Braz Monteiro.
+  This file is subject to the terms of halley_license.txt.
+
+\*****************************************************************/
+
+#ifdef __FreeBSD__
+
+#include "os_freebsd.h"
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <pwd.h>
+#include <unistd.h>
+#include <cstring>
+
+using namespace Halley;
+
+
+String execCommand(String command) {
+	FILE* fp = popen(command.c_str(), "r");
+	if (!fp) {
+		return "";
+	}
+	String result;
+	constexpr int bufSize = 1024;
+	char buffer[bufSize];
+	while (fgets(buffer, bufSize - 1, fp)) {
+		result += buffer;
+	}
+	pclose(fp);
+	return result;
+}
+
+String slice(String str, const char* from, const char* to) {
+	String low = str.asciiLower();
+	size_t pos = low.find(from);
+	if (pos == std::string::npos) {
+		return "";
+	}
+	pos += strlen(from);
+	size_t end = low.find(to, pos + 1);
+	return str.substr(pos, end - pos);
+}
+
+ComputerData OSFreeBSD::getComputerData()
+{
+	ComputerData data;
+
+	{
+		char buffer[128];
+		buffer[127] = 0;
+		gethostname(buffer, 127);
+		data.computerName = buffer;
+	}
+
+	{
+		size_t len = sizeof(data.RAM);
+		sysctlbyname("hw.physmem", &data.RAM, &len, NULL, 0);
+	}
+
+	{
+		char buffer[128] = {0};
+		size_t len = sizeof(buffer);
+		sysctlbyname("hw.model", buffer, &len, NULL, 0);
+		data.cpuName = buffer;
+	}
+
+	{
+		char buffer[128] = {0};
+		size_t len = sizeof(buffer);
+		sysctlbyname("kern.version", buffer, &len, NULL, 0);
+		data.osName = String(buffer).trimBoth();
+	}
+
+	data.gpuName = slice(execCommand("pciconf -lv vgapci0"), "device     = '", "'\n").trimBoth();
+
+	return data;
+}
+
+Path OSFreeBSD::parseProgramPath(const String& path)
+{
+	size_t len = 1024;
+	char buffer[len];
+	bzero(buffer, len);
+
+	int mib[4] = {
+		CTL_KERN,
+		KERN_PROC,
+		KERN_PROC_PATHNAME,
+		-1,
+	};
+
+	sysctl(mib, 4, buffer, &len, NULL, 0);
+	return Path(String(buffer)).parentPath() / ".";
+}
+
+String OSFreeBSD::getUserDataDir()
+{
+	String result;
+
+	if (!(result = getenv("XDG_DATA_HOME")).isEmpty()) {
+		return result;
+	} else if ((result = getenv("HOME")).isEmpty()) {
+		struct passwd* pwd = getpwuid(getuid());
+		if ((result = pwd->pw_dir).isEmpty()) {
+			throw Exception("Unable to find path to user data directory.", HalleyExceptions::OS);
+		}
+	}
+
+	return result + "/.local/share";
+}
+
+void OSFreeBSD::openURL(const String& url)
+{
+	if (url.startsWith("http://") || url.startsWith("https://")) {
+		auto str = "xdg-open " + url;
+		system(str.c_str());
+	}
+}
+
+#endif

--- a/src/engine/utils/src/os/os_freebsd.h
+++ b/src/engine/utils/src/os/os_freebsd.h
@@ -14,7 +14,7 @@
 
   ---------------------------------------------------------------
 
-  Copyright (c) 2007-2011 - Rodrigo Braz Monteiro.
+  Copyright (c) 2007-2016 - Rodrigo Braz Monteiro.
   This file is subject to the terms of halley_license.txt.
 
 \*****************************************************************/
@@ -22,23 +22,18 @@
 #pragma once
 
 
-#if defined(__APPLE__) || defined(__ANDROID__) || defined(linux) || defined(__FreeBSD__)
-#define IS_UNIX
+#ifdef __FreeBSD__
 
-#include <halley/os/os.h>
+#include "os_unix.h"
 
 namespace Halley {
-	class OSUnix : public OS {
+	class OSFreeBSD : public OSUnix {
 	public:
-		OSUnix();
-		~OSUnix();
+		String getUserDataDir() override;
+		ComputerData getComputerData() override;
+		Path parseProgramPath(const String&) override;
 
-		virtual ComputerData getComputerData() override;
-		virtual String getUserDataDir() override;
-		void createDirectories(const Path& path) override;
-		std::vector<Path> enumerateDirectory(const Path& path) override;
-
-		int runCommand(String command) override;
+		void openURL(const String& url) override;
 	};
 }
 


### PR DESCRIPTION
Everything seems to work as-is, just copied the linux stubs and replaced
them with the corresponding sysctl/fbsd utility invocations. I don't have a non-FreeBSD box to get values to compare to, but this is what's emitted on my machine with this patch:

```
Computer data:
        OS:   FreeBSD 12.0-RELEASE r343787 TWILIGHT
        CPU:  AMD FX(tm)-4100 Quad-Core Processor
        GPU:  GK107 [GeForce GT 740]
        RAM:  31.86 GB
        Time: Sun Feb 24 02:56:34 2019
```

...I do realize there's an exceptionally limited audience for this, but hey.