### PR TITLE
Add -msse3 flag to Clang as well as GCC in utils

### DIFF
--- a/src/engine/utils/CMakeLists.txt
+++ b/src/engine/utils/CMakeLists.txt
@@ -220,7 +220,7 @@ set(HEADERS
 assign_source_group(${SOURCES})
 assign_source_group(${HEADERS})
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         set_source_files_properties("src/maths/matrix4.cpp" PROPERTIES COMPILE_FLAGS "-msse3")
 endif ()
 


### PR DESCRIPTION
Noticed I couldn't build latest master on Clang any more. Seems the `-msse3` flag is needed there as well as on GCC.