### PR TITLE
Fixes a bug when >1 entities are added to and removed from 1 family in the same frame

### DIFF
--- a/src/engine/entity/include/halley/entity/family.h
+++ b/src/engine/entity/include/halley/entity/family.h
@@ -169,6 +169,8 @@ namespace Halley {
 				// Move all entities to be removed to the back of the vector
 				{
 					int n = int(entities.size());
+					std::vector<std::pair<int, int>> moves;
+					moves.reserve( removeCount );
 					// Note: it's important to scan it forward. Scanning backwards would improve performance for short-lived entities,
 					// but it causes an issue where an entity is removed and added to the same family in one frame.
 					for (int i = 0; i < n; i++) {
@@ -177,7 +179,7 @@ namespace Halley {
 						if (iter != toRemove.end() && id == *iter) {
 							toRemove.erase(iter);
 							if (i != n - 1) {
-								std::swap(entities[i], entities[n - 1]);
+								moves.emplace_back( std::make_pair( i, n - 1 ) );
 								i--;
 							}
 							n--;
@@ -185,6 +187,9 @@ namespace Halley {
 								break;
 							}
 						}
+					}
+					for (const std::pair<int, int>& move : moves) {
+						std::swap(entities[move.first], entities[move.second]);
 					}
 					Ensures(size_t(n) + removeCount == entities.size());
 				}


### PR DESCRIPTION
This should fix a small bug in the family code, namely one that occurs whenever the following is give:
* A family contains 2 or more entities
* 2 or more of those entities are deleted and added in the same frame
This bug then lead to only one of the entities to be properly updated.

The steps inside the code that lead to this problem are the following:
toRemove = {1, 2}
entities = {1(old), 2(old), 1(new), 2(new) }
During the first iteration he picks entities[0] {1(old}} and finds it in toRemove, deletes it from there and swaps it with entities[3]{ 2(new) }, leading to the following situation:
toRemove = {2}
entities = {2(new), 2(old), 1(new), 1(old) }
During the second iteration, he picks entities[0] {2(new)} and finds it in toRemove, deletes it from there and swaps it with entities[2] {1(new)}, leading to the final situation:
toRemove = {}
entities = {1(new), 2(old), 2(new), 1(old) }

This change buffers the swaps in a vector, before executing them all at once, ensuring that the swaps already executed don't change the result of later forward scans through the entities-vector.