### PR TITLE
Fixed issue with asio on linux, the callback forasync_read_some never gets called

### DIFF
--- a/src/plugins/asio/src/asio_tcp_network_service.cpp
+++ b/src/plugins/asio/src/asio_tcp_network_service.cpp
@@ -4,7 +4,8 @@
 using namespace Halley;
 
 AsioTCPNetworkService::AsioTCPNetworkService(int port, IPVersion version)
-	: localEndpoint(version == IPVersion::IPv4 ? asio::ip::tcp::v4() : asio::ip::tcp::v6(), static_cast<unsigned short>(port))
+	: work(service)
+	, localEndpoint(version == IPVersion::IPv4 ? asio::ip::tcp::v4() : asio::ip::tcp::v6(), static_cast<unsigned short>(port))
 	, acceptor(service, localEndpoint)
 {
 	Expects(port == 0 || port > 1024);

--- a/src/plugins/asio/src/asio_tcp_network_service.h
+++ b/src/plugins/asio/src/asio_tcp_network_service.h
@@ -17,6 +17,7 @@ namespace Halley
 
 	private:
 		asio::io_service service;
+		asio::io_service::work work;
 		TCPEndpoint localEndpoint;
 		asio::ip::tcp::acceptor acceptor;
 


### PR DESCRIPTION
Fixed issue with asio on linux, the callback forasync_read_some never gets called on the client side. I think it might be a problem with asio on linux. Created work object to keep the service 'alive'. This caused an issue where DevConClient never hot reloaded resources