### PR TITLE
Fix memory leak in Metal plugin

### DIFF
--- a/cmake/HalleyProject.cmake
+++ b/cmake/HalleyProject.cmake
@@ -204,6 +204,11 @@ if (USE_DX11)
 	add_definitions(-DWITH_DX11)
 endif()
 
+# Metal
+if (USE_METAL)
+	add_definitions(-DWITH_METAL)
+endif()
+
 # WinRT
 if (USE_WINRT)
 	if (${CMAKE_SYSTEM_NAME} MATCHES "WindowsStore")

--- a/src/plugins/metal/src/metal_buffer.mm
+++ b/src/plugins/metal/src/metal_buffer.mm
@@ -9,12 +9,14 @@ MetalBuffer::MetalBuffer(MetalVideo& video, Type type, size_t initialSize)
 {}
 
 MetalBuffer::~MetalBuffer() {
+	[buffer setPurgeableState:MTLPurgeableStateEmpty];
 	[buffer release];
 }
 
 void MetalBuffer::setData(gsl::span<const gsl::byte> data) {
 	auto oldBuffer = std::move(buffer);
 	buffer = [video.getDevice() newBufferWithBytes:data.data() length:data.length_bytes() options:MTLResourceStorageModeShared];
+	[oldBuffer setPurgeableState:MTLPurgeableStateEmpty];
 	[oldBuffer release];
 }
 

--- a/src/plugins/metal/src/metal_painter.mm
+++ b/src/plugins/metal/src/metal_painter.mm
@@ -16,7 +16,6 @@ void MetalPainter::clear(Colour colour) {
 	[encoder endEncoding];
 	auto descriptor = renderPassDescriptorForTextureAndColour(video.getSurface().texture, colour);
 	encoder = [buffer renderCommandEncoderWithDescriptor:descriptor];
-	[descriptor release];
 }
 
 void MetalPainter::setMaterialPass(const Material& material, int passNumber) {
@@ -51,6 +50,9 @@ void MetalPainter::setMaterialPass(const Material& material, int passNumber) {
 		auto texture = std::static_pointer_cast<const MetalTexture>(tex);
 		texture->bind(encoder, texIndex++);
 	}
+
+	[pipelineState release];
+	[pipelineStateDescriptor release];
 }
 
 void MetalPainter::doStartRender() {
@@ -58,16 +60,12 @@ void MetalPainter::doStartRender() {
 	auto col = Colour4f(0);
 	auto descriptor = renderPassDescriptorForTextureAndColour(video.getSurface().texture, col);
 	encoder = [buffer renderCommandEncoderWithDescriptor:descriptor];
-	[descriptor release];
 }
 
 void MetalPainter::doEndRender() {
 	[encoder endEncoding];
 	[buffer presentDrawable:video.getSurface()];
 	[buffer commit];
-	[encoder release];
-	[buffer release];
-	[indexBuffer release];
 }
 
 void MetalPainter::setVertices(
@@ -85,6 +83,8 @@ void MetalPainter::setVertices(
 		options:MTLResourceStorageModeShared
 	];
 	[encoder setVertexBuffer:buffer offset:0 atIndex:0];
+	[buffer setPurgeableState:MTLPurgeableStateEmpty];
+	[buffer autorelease];
 
 	indexBuffer = [video.getDevice() newBufferWithBytes:indices
 			length:numIndices*sizeof(short) options:MTLResourceStorageModeShared
@@ -101,6 +101,8 @@ void MetalPainter::drawTriangles(size_t numIndices) {
 		indexBuffer:indexBuffer
 		indexBufferOffset:0
 	];
+	[indexBuffer setPurgeableState:MTLPurgeableStateEmpty];
+	[indexBuffer release];
 }
 
 void MetalPainter::setViewPort(Rect4i rect) {

--- a/src/plugins/metal/src/metal_video.h
+++ b/src/plugins/metal/src/metal_video.h
@@ -41,6 +41,7 @@ namespace Halley {
 		id<CAMetalDrawable> surface;
 		id<MTLDevice> device;
 		id<MTLCommandQueue> command_queue;
+		NSAutoreleasePool *pool;
 
 		void initSwapChain(Window& window);
 	};

--- a/src/plugins/metal/src/metal_video.mm
+++ b/src/plugins/metal/src/metal_video.mm
@@ -30,13 +30,14 @@ void MetalVideo::deInit()
 
 void MetalVideo::startRender()
 {
+	pool = [[NSAutoreleasePool alloc] init];
 	surface = [swap_chain nextDrawable];
 }
 
 void MetalVideo::finishRender()
 {
 	window->swap();
-	[surface release];
+	[pool release];
 }
 
 

--- a/src/plugins/metal/src/metal_video.mm
+++ b/src/plugins/metal/src/metal_video.mm
@@ -1,4 +1,4 @@
-﻿#include "metal_material_constant_buffer.h"
+#include "metal_material_constant_buffer.h"
 #include "metal_painter.h"
 #include "metal_render_target.h"
 #include "metal_texture.h"


### PR DESCRIPTION
I think this works. Seems Metal expects there to be _some_ autorelease pool, whether at the application (Cocoa) layer or somewhere else. In our case it's 'somewhere else'.