### PR TITLE
Fixing Metal shader build errors

### DIFF
--- a/shared_assets/shader/distance_field_sprite.pixel.metal
+++ b/shared_assets/shader/distance_field_sprite.pixel.metal
@@ -18,6 +18,12 @@ struct VertexOut {
 	float4 position [[ position ]];
 };
 
+// TODO: Move this out as a common util
+// There's no lerp function defined in Metal's standard library
+float4 lerp(float4 a, float4 b, float factor) {
+    return a * (1 - factor) + b * factor;
+}
+
 fragment float4 pixel_func (
 	VertexOut v [[ stage_in ]],
 	texture2d<float> tex0 [[ texture(0) ]],
@@ -37,8 +43,7 @@ fragment float4 pixel_func (
 	float outline = 1.0 - smoothstep(inEdge - s, inEdge + s, a);
 	float4 colFill = v.colour;
 	float4 colOutline = material.outlineColour;
-	float4 col = mix(colFill, colOutline, outline);
-
 	float4 col = lerp(colFill, colOutline, outline);
+
 	return float4(col.rgb, col.a * edge);
 }

--- a/shared_assets/shader/distance_field_sprite.pixel.metal
+++ b/shared_assets/shader/distance_field_sprite.pixel.metal
@@ -18,12 +18,6 @@ struct VertexOut {
 	float4 position [[ position ]];
 };
 
-// TODO: Move this out as a common util
-// There's no lerp function defined in Metal's standard library
-float4 lerp(float4 a, float4 b, float factor) {
-    return a * (1 - factor) + b * factor;
-}
-
 fragment float4 pixel_func (
 	VertexOut v [[ stage_in ]],
 	texture2d<float> tex0 [[ texture(0) ]],
@@ -43,7 +37,7 @@ fragment float4 pixel_func (
 	float outline = 1.0 - smoothstep(inEdge - s, inEdge + s, a);
 	float4 colFill = v.colour;
 	float4 colOutline = material.outlineColour;
-	float4 col = lerp(colFill, colOutline, outline);
+	float4 col = mix(colFill, colOutline, outline);
 
 	return float4(col.rgb, col.a * edge);
 }

--- a/shared_assets/shader/distance_field_sprite_fill.pixel.metal
+++ b/shared_assets/shader/distance_field_sprite_fill.pixel.metal
@@ -36,6 +36,7 @@ fragment float4 pixel_func (
 	float edge1 = clamp(inEdge + s, edge0 + 0.01, 0.99);
 	float edge = smoothstep(edge0, edge1, a) * v.colour.a;
 
+	float4 colFill = v.colour;
 	float alpha = colFill.a * edge;
 	return float4(colFill.rgb * alpha, alpha);
 }


### PR DESCRIPTION
I'm trying to build https://github.com/amzeratul/ggj20 with the latest version of Halley on MacOS but it looks like https://github.com/amzeratul/halley/commit/fc6bdfbe2d0b1675b9db481bae42f4f45b21440a broke compilation recently with respect to the Metal shaders. 

```
ggj20 $ ./halley/bin/halley-editor

...

Initializing Video Display...
Drivers available:
	0: cocoa
	1: dummy
Video driver: cocoa
	Got Metal device: Intel(R) Iris(TM) Graphics 6100

Starting main loop.
Metal shader compilation failed for material Halley/DistanceFieldSprite/pass0


Unhandled exception: Compilation failed:

program_source:42:9: error: redefinition of 'col'
        float4 col = lerp(colFill, colOutline, outline);
        ^
program_source:40:9: note: previous definition is here
        float4 col = mix(colFill, colOutline, outline);
        ^
program_source:42:15: error: use of undeclared identifier 'lerp'
        float4 col = lerp(colFill, colOutline, outline);
              ^
```

I've fixed the compilation issues, but it looks like these are still causing `halley-editor` to crash with the following error:

```
...
Starting main loop.
Executor aborting due to exception.
Unknown texture format
```

This should be safe to merge for now though as I also rolled back to https://github.com/amzeratul/halley/commit/a34c326c25b9986267870a94f7f0f75eb6ae48de and it failed with the same error.