### PR TITLE
Properly handle TextureFormat::Red for Metal

### DIFF
--- a/src/plugins/metal/src/metal_texture.mm
+++ b/src/plugins/metal/src/metal_texture.mm
@@ -16,6 +16,7 @@ void MetalTexture::load(TextureDescriptor&& descriptor)
 	int bytesPerPixel = 0;
 	switch (descriptor.format) {
 		case TextureFormat::Indexed:
+		case TextureFormat::Red:
 			pixelFormat = MTLPixelFormatR8Unorm;
 			bytesPerPixel = 1;
 			break;


### PR DESCRIPTION
This is a fix for the other issue mentioned in https://github.com/amzeratul/halley/pull/77, which I ended up bisecting to: https://github.com/amzeratul/halley/commit/a23282d174e0ac876b3dc282acf5b830887f18c9.

Trying to start `halley-editor` with Metal would throw the following:
```
...
Starting main loop.
Executor aborting due to exception.
Unknown texture format
```

