### PR TITLE
Fix ambiguous call to clamp() in solid line shader for Metal

### DIFF
--- a/shared_assets/shader/line_solid.pixel.metal
+++ b/shared_assets/shader/line_solid.pixel.metal
@@ -14,7 +14,7 @@ fragment float4 pixel_func (
 ) {
 	float edge = vert.width * 0.5;
 	float invFeather = 2.0 / dfdx(vert.worldPos.x);
-	float v = clamp((edge - abs(vert.vertPos)) * invFeather, -1, 1) * 0.5 + 0.5;
+	float v = clamp((edge - abs(vert.vertPos)) * invFeather, -1.0f, 1.0f) * 0.5 + 0.5;
 	float a = vert.colour.a * v;
 
 	return float4(vert.colour.rgb * a, a);


### PR DESCRIPTION
This fixes the following issue that I ran into today while building https://github.com/amzeratul/ggj20 on the latest version of Halley:

```
Video driver: cocoa
	Got Metal device: Intel(R) Iris(TM) Graphics 6100
Audio Playback started.
	Device: [Default] [0]
	Sample rate: 48000
	Channels: 2
	Format: float
	Buffer size: 512

Starting main loop.
Metal shader compilation failed for material Halley/SolidLine/pass0


Unhandled exception: Compilation failed:

program_source:17:12: error: call to 'clamp' is ambiguous
        float v = clamp((edge - abs(vert.vertPos)) * invFeather, -1, 1) * 0.5 + 0.5;
           ^~~~~
/System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/3902/Libraries/lib/clang/902.11/include/metal/metal_common:124:18: note: candidate function
METAL_FUNC float clamp(float x, float minval, float maxval)
                 ^
/System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/3902/Libraries/lib/clang/902.11/include/metal/metal_integer:1625:16: note: candidate function
METAL_FUNC int clamp(int x, int minval, int maxval)
               ^
...
```