### PR TITLE
Fix some Xcode errors with Metal textures

### DIFF
--- a/src/plugins/metal/src/metal_painter.mm
+++ b/src/plugins/metal/src/metal_painter.mm
@@ -23,7 +23,8 @@ void MetalPainter::setMaterialPass(const Material& material, int passNumber) {
 	auto& pass = material.getDefinition().getPass(passNumber);
 	MetalShader& shader = static_cast<MetalShader&>(pass.getShader());
 
-	auto pipelineStateDescriptor = shader.setupMaterial(material);
+	auto& renderTarget = dynamic_cast<IMetalRenderTarget&>(getActiveRenderTarget());
+	auto pipelineStateDescriptor = shader.setupMaterial(material, renderTarget.getMetalTexture());
 	setBlending(pass.getBlend(), pipelineStateDescriptor.colorAttachments[0]);
 
 	NSError* error = NULL;

--- a/src/plugins/metal/src/metal_shader.h
+++ b/src/plugins/metal/src/metal_shader.h
@@ -13,7 +13,7 @@ namespace Halley {
 		~MetalShader();
 		int getUniformLocation(const String& name, ShaderType stage) override;
 		int getBlockLocation(const String& name, ShaderType stage) override;
-		MTLRenderPipelineDescriptor* setupMaterial(const Material& material);
+		MTLRenderPipelineDescriptor* setupMaterial(const Material& material, id<MTLTexture> renderTargetTexture);
 
 	private:
 		MetalVideo& video;

--- a/src/plugins/metal/src/metal_shader.mm
+++ b/src/plugins/metal/src/metal_shader.mm
@@ -63,7 +63,7 @@ int MetalShader::getBlockLocation(const String& name, ShaderType type)
 	return -1;
 }
 
-MTLRenderPipelineDescriptor* MetalShader::setupMaterial(const Material& material) {
+MTLRenderPipelineDescriptor* MetalShader::setupMaterial(const Material& material, id<MTLTexture> renderTargetTexture) {
 	if (descriptor) {
 		return descriptor;
 	}
@@ -72,7 +72,7 @@ MTLRenderPipelineDescriptor* MetalShader::setupMaterial(const Material& material
 	descriptor.vertexFunction = vertex_func;
 	descriptor.fragmentFunction = fragment_func;
 	descriptor.label = [NSString stringWithUTF8String:material.getDefinition().getName().c_str()];
-	descriptor.colorAttachments[0].pixelFormat = video.getSurface().texture.pixelFormat;
+	descriptor.colorAttachments[0].pixelFormat = renderTargetTexture.pixelFormat;
 
 	vertex_descriptor = [[MTLVertexDescriptor alloc] init];
 	for (size_t i = 0; i < material.getDefinition().getAttributes().size(); ++i) {

--- a/src/plugins/metal/src/metal_texture.h
+++ b/src/plugins/metal/src/metal_texture.h
@@ -23,5 +23,6 @@ namespace Halley {
 		id<MTLSamplerState> sampler;
 
 		static MTLSamplerAddressMode getMetalAddressMode(TextureDescriptor& descriptor);
+		static MTLTextureUsage getMetalTextureUsage(TextureDescriptor& descriptor);
 	};
 }

--- a/src/plugins/metal/src/metal_texture.mm
+++ b/src/plugins/metal/src/metal_texture.mm
@@ -40,6 +40,7 @@ void MetalTexture::doLoad(TextureDescriptor& descriptor)
 		height:descriptor.size.y
 		mipmapped:descriptor.useMipMap
 	];
+	textureDescriptor.usage = getMetalTextureUsage(descriptor);
 	metalTexture = [video.getDevice() newTextureWithDescriptor:textureDescriptor];
 
 	NSUInteger bytesPerRow = bytesPerPixel * descriptor.size.x;
@@ -99,4 +100,13 @@ MTLSamplerAddressMode MetalTexture::getMetalAddressMode(TextureDescriptor& descr
 	case TextureAddressMode::Repeat:
 		return MTLSamplerAddressModeRepeat;
 	}
+}
+
+MTLTextureUsage MetalTexture::getMetalTextureUsage(TextureDescriptor& descriptor)
+{
+	MTLTextureUsage usage = MTLTextureUsageShaderRead;
+	if (descriptor.isRenderTarget) {
+		return usage | MTLTextureUsageRenderTarget;
+	}
+	return usage;
 }


### PR DESCRIPTION
Xcode is stricter in its runtime Metal validation than the built executable is; this fixes the errors it was complaining about.

- Mark texture usage on descriptor
- Ensure pixel formats match up in RTT 