### PR TITLE
Prefab vs. Instance UUIDs

### DIFF
--- a/src/engine/entity/include/halley/entity/entity.h
+++ b/src/engine/entity/include/halley/entity/entity.h
@@ -115,9 +115,14 @@ namespace Halley {
 			return fromPrefab;
 		}
 		
-		const UUID& getUUID() const
+		const UUID& getPrefabUUID() const
 		{
-			return uuid;
+			return prefabUUID;
+		}
+
+		const UUID& getInstanceUUID() const
+		{
+			return instanceUUID;
 		}
 
 		FamilyMaskType getMask() const;
@@ -150,7 +155,8 @@ namespace Halley {
 		FamilyMaskType mask;
 		EntityId entityId;
 		String name;
-		UUID uuid;
+		UUID instanceUUID;
+		UUID prefabUUID;
 
 		Entity();
 		void destroyComponents(ComponentDeleterTable& storage);
@@ -198,6 +204,7 @@ namespace Halley {
 		void detachChildren();
 		void markHierarchyDirty();
 		void propagateChildrenChange();
+		void propagateChildWorldPartition(uint8_t newWorldPartition);
 
 		void doDestroy(bool updateParenting);
 
@@ -378,10 +385,16 @@ namespace Halley {
 			entity->name = std::move(name);
 		}
 
-		const UUID& getUUID() const
+		const UUID& getInstanceUUID() const
 		{
 			Expects(entity != nullptr);
-			return entity->uuid;
+			return entity->instanceUUID;
+		}
+
+		const UUID& getPrefabUUID() const
+		{
+			Expects(entity != nullptr);
+			return entity->prefabUUID;
 		}
 
 		void keepOnlyComponentsWithIds(const std::vector<int>& ids)
@@ -602,9 +615,14 @@ namespace Halley {
 			return entity->name;
 		}
 
-		const UUID& getUUID() const
+		const UUID& getInstanceUUID() const
 		{
-			return entity->uuid;
+			return entity->instanceUUID;
+		}
+
+		const UUID& getPrefabUUID() const
+		{
+			return entity->prefabUUID;
 		}
 
 		bool hasParent() const

--- a/src/engine/entity/include/halley/entity/entity.h
+++ b/src/engine/entity/include/halley/entity/entity.h
@@ -131,7 +131,7 @@ namespace Halley {
 		void refresh(MaskStorage& storage, ComponentDeleterTable& table);
 		void destroy();
 		
-		void sortChildren(const std::vector<UUID>& uuids);
+		void sortChildrenByPrefabUUIDs(const std::vector<UUID>& uuids);
 
 		void setWorldPartition(uint8_t partition);
 
@@ -559,10 +559,10 @@ namespace Halley {
 			return entity->isFromPrefab();
 		}
 
-		void sortChildren(const std::vector<UUID>& uuids)
+		void sortChildrenByPrefabUUIDs(const std::vector<UUID>& uuids)
 		{
 			Expects(entity);
-			entity->sortChildren(uuids);
+			entity->sortChildrenByPrefabUUIDs(uuids);
 		}
 
 	private:

--- a/src/engine/entity/include/halley/entity/entity_factory.h
+++ b/src/engine/entity/include/halley/entity/entity_factory.h
@@ -61,11 +61,13 @@ namespace Halley {
 		ConfigNode dummyPrefab;
 
 		void createEntityTreeForScene(const ConfigNode& node, EntityScene& curScene, std::shared_ptr<const Prefab> prefab, std::optional<int> index = {});
-		EntityRef createEntityTree(const ConfigNode& node, EntityScene* curScene);
-		EntityRef createEntity(std::optional<EntityRef> parent, const ConfigNode& node, bool populate, EntityScene* curScene);
+		EntityRef createEntityTree(const ConfigNode& node, EntityScene* curScene, bool fromPrefab);
+		EntityRef createEntity(std::optional<EntityRef> parent, const ConfigNode& node, bool populate, EntityScene* curScene, bool fromPrefab, bool isPrefabRoot);
 		
 		void updateEntity(EntityRef& entity, const ConfigNode& node, UpdateMode mode = UpdateMode::UpdateAll);
-		void doUpdateEntityTree(EntityRef& entity, const ConfigNode& node, bool refreshing);
+		void doUpdateEntityTree(EntityRef& entity, const ConfigNode& node, bool refreshing, bool isPrefabRoot);
+		void rebuildPrefabContext(const ConfigNode& treeNode);
+		void rebuildPrefabContext(EntityRef& entity);
 		void rebuildContext(EntityRef& entity, const ConfigNode& node);
 		
 		std::shared_ptr<const Prefab> getPrefab(const String& id) const;
@@ -81,6 +83,7 @@ namespace Halley {
 	public:
 		World& world;
 		std::map<UUID, EntityId> uuids;
+		std::vector<std::map<UUID, UUID>> uuidMapping; //prefab -> instance
 
 		EntitySerializationContext(World& world);
 

--- a/src/engine/entity/include/halley/entity/world.h
+++ b/src/engine/entity/include/halley/entity/world.h
@@ -73,7 +73,7 @@ namespace Halley {
 
 		EntityRef createEntity(String name = "", std::optional<EntityRef> parent = {});
 		EntityRef createEntity(String name, EntityId parentId);
-		EntityRef createEntity(UUID uuid, String name = "", std::optional<EntityRef> parent = {}, bool fromPrefab = false);
+		EntityRef createEntity(UUID uuid, String name = "", std::optional<EntityRef> parent = {}, bool fromPrefab = false, UUID prefabUUID = UUID());
 		EntityRef createEntity(UUID uuid, String name, EntityId parentId);
 
 		void destroyEntity(EntityId id);

--- a/src/engine/entity/src/entity.cpp
+++ b/src/engine/entity/src/entity.cpp
@@ -107,7 +107,10 @@ void Entity::setParent(Entity* newParent, bool propagate)
 		// Reparent
 		if (newParent) {
 			parent = newParent;
-			worldPartition = newParent->worldPartition;
+			if (worldPartition != newParent->worldPartition) {
+				worldPartition = newParent->worldPartition;				
+				propagateChildWorldPartition(worldPartition);
+			}
 			parent->children.push_back(this);
 			parent->propagateChildrenChange();
 		}
@@ -152,6 +155,14 @@ void Entity::propagateChildrenChange()
 	// Could be recursive, but want to make sure I'm not paying for function calls here
 	for (Entity* cur = this; cur; cur = cur->parent) {
 		cur->childrenRevision++;
+	}
+}
+
+void Entity::propagateChildWorldPartition(uint8_t newWorldPartition)
+{
+	worldPartition = newWorldPartition;
+	for (auto& child : children) {
+		child->propagateChildWorldPartition(newWorldPartition);
 	}
 }
 
@@ -206,7 +217,7 @@ void Entity::sortChildren(const std::vector<UUID>& uuids)
 	if (nChildren == uuids.size()) {
 		bool allMatch = true;
 		for (size_t i = 0; i < nChildren; ++i) {
-			if (children[i]->uuid != uuids[i]) {
+			if (children[i]->instanceUUID != uuids[i]) {
 				allMatch = false;
 				break;
 			}
@@ -220,7 +231,7 @@ void Entity::sortChildren(const std::vector<UUID>& uuids)
 	Vector<std::pair<Entity*, size_t>> pairs(nChildren);
 	
 	for (size_t i = 0; i < nChildren; ++i) {
-		const size_t idx = std::find(uuids.begin(), uuids.end(), children[i]->uuid) - uuids.begin();
+		const size_t idx = std::find(uuids.begin(), uuids.end(), children[i]->instanceUUID) - uuids.begin();
 		pairs[i] = std::make_pair(children[i], idx);
 	}
 

--- a/src/engine/entity/src/entity.cpp
+++ b/src/engine/entity/src/entity.cpp
@@ -209,7 +209,7 @@ void Entity::destroy()
 	doDestroy(true);
 }
 
-void Entity::sortChildren(const std::vector<UUID>& uuids)
+void Entity::sortChildrenByPrefabUUIDs(const std::vector<UUID>& uuids)
 {
 	const size_t nChildren = children.size();
 
@@ -217,7 +217,7 @@ void Entity::sortChildren(const std::vector<UUID>& uuids)
 	if (nChildren == uuids.size()) {
 		bool allMatch = true;
 		for (size_t i = 0; i < nChildren; ++i) {
-			if (children[i]->instanceUUID != uuids[i]) {
+			if (children[i]->prefabUUID != uuids[i]) {
 				allMatch = false;
 				break;
 			}

--- a/src/engine/entity/src/entity_factory.cpp
+++ b/src/engine/entity/src/entity_factory.cpp
@@ -277,7 +277,7 @@ void EntityFactory::updateEntityTree(EntityRef& entity, const ConfigNode& node, 
 	if (doRebuildContext) {
 		rebuildContext(entity, node);
 	}
-	doUpdateEntityTree(entity, node, true, false);
+	doUpdateEntityTree(entity, node, true, true);
 }
 
 void EntityFactory::updateScene(std::vector<EntityRef>& entities, const ConfigNode& node)
@@ -386,7 +386,7 @@ void EntityFactory::doUpdateEntityTree(EntityRef& entity, const ConfigNode& tree
 		}
 	}
 
-	entity.sortChildren(nodeUUIDs);
+	entity.sortChildrenByPrefabUUIDs(nodeUUIDs);
 
 	if (isPrefab || isPrefabRoot) {
 		context.entityContext->uuidMapping.pop_back();

--- a/src/engine/entity/src/entity_id.cpp
+++ b/src/engine/entity/src/entity_id.cpp
@@ -9,7 +9,7 @@ using namespace Halley;
 String EntityId::toUUID(const EntityId& id, ConfigNodeSerializationContext& context)
 {
 	auto& world = context.entityContext->world;
-	return world.getEntity(id).getUUID().toString();
+	return world.getEntity(id).getInstanceUUID().toString();
 }
 
 EntityId EntityId::fromUUID(const String& uuidStr, ConfigNodeSerializationContext& context)
@@ -17,6 +17,14 @@ EntityId EntityId::fromUUID(const String& uuidStr, ConfigNodeSerializationContex
 	const auto iter = context.entityContext->uuids.find(UUID(uuidStr));
 	if (iter != context.entityContext->uuids.end()) {
 		return iter->second;
+	}
+
+	const auto& prefabIter = context.entityContext->uuidMapping.back().find(UUID(uuidStr));	
+	if (prefabIter != context.entityContext->uuidMapping.back().end()) {
+		const auto& instanceIter = context.entityContext->uuids.find(prefabIter->second);
+		if (instanceIter != context.entityContext->uuids.end()) {
+			return instanceIter->second;
+		}
 	}
 	return EntityId();
 }

--- a/src/engine/entity/src/scene_editor/scene_editor.cpp
+++ b/src/engine/entity/src/scene_editor/scene_editor.cpp
@@ -254,7 +254,7 @@ void SceneEditor::changeZoom(int amount, Vector2f cursorPosRelToCamera)
 
 void SceneEditor::setSelectedEntity(const UUID& id, ConfigNode& entityData)
 {
-	const auto curId = selectedEntity ? selectedEntity.value().getUUID() : UUID();
+	const auto curId = selectedEntity ? selectedEntity.value().getInstanceUUID() : UUID();
 	if (id != curId) {
 		selectedEntity.reset();
 		if (id.isValid()) {
@@ -382,7 +382,7 @@ void SceneEditor::onInit()
 
 EntityRef SceneEditor::getEntity(const UUID& id) const
 {
-	const auto curId = selectedEntity ? selectedEntity.value().getUUID() : UUID();
+	const auto curId = selectedEntity ? selectedEntity.value().getInstanceUUID() : UUID();
 	if (curId == id) {
 		return selectedEntity.value();
 	} else {
@@ -436,7 +436,7 @@ void SceneEditor::onClick(const SceneEditorInputState& input, SceneEditorOutputS
 	if (bestEntity.isValid()) {
 		std::vector<UUID> uuids;
 		for (auto e = bestEntity; e.isValid(); e = e.getParent()) {
-			uuids.push_back(e.getUUID());
+			uuids.push_back(e.getInstanceUUID());
 		}
 		output.newSelection = uuids;
 	} else {

--- a/src/engine/entity/src/world.cpp
+++ b/src/engine/entity/src/world.cpp
@@ -169,7 +169,7 @@ EntityRef World::createEntity(String name, EntityId parentId)
 	return createEntity(UUID(), name, getEntity(parentId));
 }
 
-EntityRef World::createEntity(UUID uuid, String name, std::optional<EntityRef> parent, bool fromPrefab)
+EntityRef World::createEntity(UUID uuid, String name, std::optional<EntityRef> parent, bool fromPrefab, UUID prefabUUID)
 {
 	if (!uuid.isValid()) {
 		uuid = UUID::generate();
@@ -179,8 +179,9 @@ EntityRef World::createEntity(UUID uuid, String name, std::optional<EntityRef> p
 	if (entity == nullptr) {
 		throw Exception("Error creating entity - out of memory?", HalleyExceptions::Entity);
 	}
-	entity->uuid = uuid;
+	entity->instanceUUID = uuid;
 	entity->fromPrefab = fromPrefab;
+	entity->prefabUUID = prefabUUID;
 	
 	entitiesPendingCreation.push_back(entity);
 	allocateEntity(entity);
@@ -246,14 +247,14 @@ Entity* World::tryGetRawEntity(EntityId id)
 std::optional<EntityRef> World::findEntity(const UUID& id, bool includePending)
 {
 	for (auto& e: entities) {
-		if (e->getUUID() == id) {
+		if (e->getInstanceUUID() == id) {
 			return EntityRef(*e, *this);
 		}
 	}
 
 	if (includePending) {
 		for (auto& e : entitiesPendingCreation) {
-			if (e->getUUID() == id) {
+			if (e->getInstanceUUID() == id) {
 				return EntityRef(*e, *this);
 			}
 		}

--- a/src/tools/editor/src/scene/scene_editor_window.cpp
+++ b/src/tools/editor/src/scene/scene_editor_window.cpp
@@ -149,7 +149,7 @@ void SceneEditorWindow::loadScene(AssetType assetType, const Prefab& origPrefab)
 
 		// Show root
 		if (!sceneCreated.getEntities().empty()) {
-			panCameraToEntity(sceneCreated.getEntities().at(0).getUUID().toString());
+			panCameraToEntity(sceneCreated.getEntities().at(0).getInstanceUUID().toString());
 		}
 		currentEntityScene = sceneCreated;
 


### PR DESCRIPTION
* When a prefab is created, its children are given instance UUIDs and with prefab UUIDs. This allows separate entities to be parented to its children.
* Chunk partitions are propagated down to children