### PR TITLE
Unbind texture units bound to render target textures

### DIFF
--- a/src/plugins/dx11/src/dx11_painter.h
+++ b/src/plugins/dx11/src/dx11_painter.h
@@ -51,6 +51,7 @@ namespace Halley
 
 		size_t curBuffer = 0;
 		std::optional<Rect4i> clipping;
+		std::vector<int> renderTargetTextureUnits;
 
 		DX11Blend& getBlendMode(BlendType type);
 		void rotateBuffers();
@@ -61,5 +62,7 @@ namespace Halley
 
 		DX11DepthStencil& getDepthStencil(const MaterialDepthStencil& depthStencil);
 		void setDepthStencil(const MaterialDepthStencil& depthStencil);
+
+		void unbindRenderTargetTextureUnits(size_t lastIndex, int minimumTextureUnit);
 	};
 }


### PR DESCRIPTION
If a render target texture is bound to unit N, and follow-up material passes use less texture units, the render target texture remains bound. This causes DX11 to spam warnings in debug builds when using it as a render target later.

Note: the change probably looks more involved than it needs to be, but I tried to minimize actual D3D calls. In most cases, there shouldn't be any noticeable overhead to the current version.